### PR TITLE
Move command and control to VaM plugin

### DIFF
--- a/LaunchServerLib/VAMLaunchServer.cs
+++ b/LaunchServerLib/VAMLaunchServer.cs
@@ -1,22 +1,18 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace VAMLaunch
 {
-    public class PositionUpdateEventArgs : EventArgs
+    public class CommandEventArgs : EventArgs
     {
-        // 0-99, in Launch FW 1.2 message units
-        public uint Position;
-        // 0-99, in Launch FW 1.2 message units
-        public uint Speed;
-        // time in decimal seconds
-        public float Duration;
+        public Command Command;
     }
 
 
     public class VAMLaunchServer
     {
-        public EventHandler<PositionUpdateEventArgs> PositionUpdate;
+        public EventHandler<CommandEventArgs> CommandUpdate;
         private const string SERVER_IP = "127.0.0.1";
         private const int SERVER_LISTEN_PORT = 15601;
         private const int SERVER_SEND_PORT = 15600;
@@ -32,10 +28,7 @@ namespace VAMLaunch
 
         private bool _running;
 
-        private byte _latestLaunchPos;
-        private byte _latestLaunchSpeed;
-        private float _latestLaunchDuration;
-        private bool _hasNewLaunchSnapshot;
+        private bool _hasNewCommands;
         private DateTime _timeOfLastLaunchUpdate;
 
         public void Run()
@@ -100,30 +93,100 @@ namespace VAMLaunch
             TimeSpan timeSinceLastUpdate = now - _timeOfLastLaunchUpdate;
             if (timeSinceLastUpdate.TotalSeconds > LAUNCH_UPDATE_INTERVAL)
             {
-                if (_hasNewLaunchSnapshot)
+                if (_hasNewCommands)
                 {
-                    PositionUpdate?.Invoke(this, new PositionUpdateEventArgs { Position = _latestLaunchPos, Speed = _latestLaunchSpeed, Duration = _latestLaunchDuration });
-                    _hasNewLaunchSnapshot = false;
+                    foreach(var cmd in _latestCommands.Values)
+                    {
+                        CommandUpdate?.Invoke(this, new CommandEventArgs { Command = cmd });
+                    }
+                    _hasNewCommands = false;
                 }
                 
                 _timeOfLastLaunchUpdate = now;
             }
         }
 
+        private Dictionary<(int, int, int), Command> _latestCommands = new Dictionary<(int, int, int), Command>();
         private void ProcessNetworkMessages()
         {
-            byte[] msg = _network.GetNextMessage();
-            if (msg != null && msg.Length == 6)
+            var cmd = Command.Parse(_network.GetNextMessage());
+            if(cmd != null)
             {
-                _latestLaunchPos = msg[0];
-                _latestLaunchSpeed = msg[1];
-                _latestLaunchDuration = BitConverter.ToSingle(msg, 2);
-
-//                Console.WriteLine("Receiving: P:{0}, S:{1}, D:{2}", _latestLaunchPos, _latestLaunchSpeed,
-//                    _latestLaunchDuration);
-                
-                _hasNewLaunchSnapshot = true;
+                _latestCommands[(cmd.Type, cmd.Device, cmd.Motor)] = cmd;
+                _hasNewCommands = true;
             }
         }
+    }
+
+    public class Command
+    {
+        public const byte LINEAR_CMD = 0;
+        public const byte VIBRATE_CMD = 1;
+        public const byte ROTATE_CMD = 2;
+
+        public const byte DEVICE_ALL = 0;
+        public const byte MOTOR_ALL = 0;
+
+        public int Type;
+        public int Device;
+        public int Motor;
+        public List<float> Params;
+
+        public Command()
+        {
+            Type = -1;
+            Device = DEVICE_ALL;
+            Motor = MOTOR_ALL;
+            Params = new List<float>();
+        }
+
+        public static Command Parse(byte[] data)
+        {
+            if(data == null || data.Length < 4)
+            {
+                return null;
+            }
+
+            var cmd = new Command()
+            {
+                Device = data[2],
+                Motor = data[3]
+            };
+
+            switch(data[1])
+            {
+                case LINEAR_CMD:
+                    if(data.Length < 12)
+                    {
+                        return null;
+                    }
+                    cmd.Type = LINEAR_CMD;
+                    cmd.Params.Add(BitConverter.ToSingle(data, 4)); // duration
+                    cmd.Params.Add(BitConverter.ToSingle(data, 8)); // position
+                    break;
+                case VIBRATE_CMD:
+                    if(data.Length < 8)
+                    {
+                        return null;
+                    }
+                    cmd.Type = VIBRATE_CMD;
+                    cmd.Params.Add(BitConverter.ToSingle(data, 4)); // speed
+                    break;
+                case ROTATE_CMD:
+                    if(data.Length < 9)
+                    {
+                        return null;
+                    }
+                    cmd.Type = ROTATE_CMD;
+                    cmd.Params.Add(BitConverter.ToSingle(data, 4)); // speed
+                    cmd.Params.Add((float)data[8]); // clockwise
+                    break;
+                default:
+                    return null;
+            }
+
+            return cmd;
+        }
+
     }
 }

--- a/LaunchServerLib/VAMLaunchServer.cs
+++ b/LaunchServerLib/VAMLaunchServer.cs
@@ -99,6 +99,7 @@ namespace VAMLaunch
                     {
                         CommandUpdate?.Invoke(this, new CommandEventArgs { Command = cmd });
                     }
+                    _latestCommands.Clear();
                     _hasNewCommands = false;
                 }
                 

--- a/VAMLaunch/ADD_ME.cslist
+++ b/VAMLaunch/ADD_ME.cslist
@@ -5,3 +5,4 @@ src/MotionSources/IMotionSource.cs
 src/MotionSources/ZoneSource.cs
 src/MotionSources/OscillateSource.cs
 src/MotionSources/PatternSource.cs
+src/MotionSources/ManualSource.cs

--- a/VAMLaunch/VAMLaunch.csproj
+++ b/VAMLaunch/VAMLaunch.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="src\LaunchUtils.cs" />
     <Compile Include="src\MotionSources\IMotionSource.cs" />
+    <Compile Include="src\MotionSources\ManualSource.cs" />
     <Compile Include="src\MotionSources\OscillateSource.cs" />
     <Compile Include="src\MotionSources\PatternSource.cs" />
     <Compile Include="src\MotionSources\ZoneSource.cs" />

--- a/VAMLaunch/src/MotionSources/ManualSource.cs
+++ b/VAMLaunch/src/MotionSources/ManualSource.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace VAMLaunchPlugin.MotionSources
+{
+
+    class Command
+    {
+        public string Method;
+        public int Device;
+        public int Motor;
+        public float Percent;
+    }
+
+    public class ManualSource : IMotionSource
+    {
+
+        List<JSONStorableFloat> _storableCommands = new List<JSONStorableFloat>();
+        List<UIDynamicSlider> _uiCommands = new List<UIDynamicSlider>();
+        VAMLaunch _plugin;
+
+        Dictionary<string, Command> _flattenedCommandQueue = new Dictionary<string, Command>();
+        private void EnqueueVibration(int device, int motor, float percent)
+        {
+            var key = $"vibration-{device}-{motor}";
+            //SuperController.LogMessage($"enqueue {key}");
+            lock(_flattenedCommandQueue)
+            {
+                _flattenedCommandQueue[key] = new Command
+                {
+                    Method = "vibration",
+                    Device = device,
+                    Motor = motor,
+                    Percent = percent
+                };
+            }
+        }
+
+        public void OnInitStorables(VAMLaunch plugin)
+        {
+            _plugin = plugin;
+            _storableCommands = new List<JSONStorableFloat>();
+
+            _storableCommands.Add(new JSONStorableFloat("Vibrate All", 0, (float x) => { EnqueueVibration(0, 0, x); }, 0, 1, constrain: true, interactable: true));
+            for (var i = 0; i < 3; i++)
+            {
+                var device = i + 1;
+                _storableCommands.Add(new JSONStorableFloat($"Vibrate Dev {i + 1} : All", 0, (float x) => { EnqueueVibration(device, 0, x); }, 0, 1, constrain: true, interactable: true));
+                _storableCommands.Add(new JSONStorableFloat($"Vibrate Dev {i + 1} : Motor 1", 0, (float x) => { EnqueueVibration(device, 1, x); }, 0, 1, constrain: true, interactable: true));
+                _storableCommands.Add(new JSONStorableFloat($"Vibrate Dev {i + 1} : Motor 2", 0, (float x) => { EnqueueVibration(device, 2, x); }, 0, 1, constrain: true, interactable: true));
+            }
+
+            foreach(var s in _storableCommands)
+            {
+                plugin.RegisterFloat(s);
+            }
+        }
+        
+        public void OnInit(VAMLaunch plugin)
+        {
+            lock(_flattenedCommandQueue)
+            {
+                _flattenedCommandQueue = new Dictionary<string, Command>();
+            }
+
+            _uiCommands = new List<UIDynamicSlider>();
+            foreach(var s in _storableCommands)
+            {
+                _uiCommands.Add(plugin.CreateSlider(s, rightSide: true));
+            }
+
+        }
+
+        public void OnDestroy(VAMLaunch plugin)
+        {
+            foreach(var ui in _uiCommands)
+            {
+                plugin.RemoveSlider(ui);
+            }
+            _uiCommands = new List<UIDynamicSlider>();
+
+            foreach(var s in _storableCommands)
+            {
+                plugin.RemoveSlider(s);
+            }
+            _storableCommands = new List<JSONStorableFloat>();
+
+            _plugin = null;
+        }
+
+
+
+        public void OnSimulatorUpdate(float prevPos, float newPos, float deltaTime)
+        {
+        }
+
+        public bool OnUpdate(ref byte outPos, ref byte outSpeed)
+        {
+            if(_plugin == null)
+            {
+                return false; // always return false since this class handles sending the commands
+            }
+
+            var commands = new List<Command>();
+            lock(_flattenedCommandQueue)
+            {
+                commands = _flattenedCommandQueue.Values.ToList();
+                _flattenedCommandQueue = new Dictionary<string, Command>();
+            }
+
+            foreach(var cmd in commands)
+            {
+                if(cmd.Method.Equals("vibration"))
+                {
+                    //SuperController.LogMessage($"Vibrate {cmd.Device} {cmd.Motor} {cmd.Percent}");
+                    _plugin.SetVibration(cmd.Device, cmd.Motor, cmd.Percent);
+                }
+            }
+
+            return false; // always return false since this class handles sending the commands
+        }
+    }
+}

--- a/VAMLaunch/src/VAMLaunch.cs
+++ b/VAMLaunch/src/VAMLaunch.cs
@@ -235,7 +235,6 @@ namespace VAMLaunchPlugin
         }
 
         
-        private static byte[] _launchData = new byte[6];
         private void SendLaunchPosition(byte pos, byte speed)
         {
             SetSimulatorTarget(pos, speed);
@@ -247,22 +246,12 @@ namespace VAMLaunchPlugin
 
             if (!_pauseLaunchMessages.val)
             {
-                _launchData[0] = pos;
-                _launchData[1] = speed;
-
                 float dist = Mathf.Abs(pos - _lastSentLaunchPos);
                 float duration = LaunchUtils.PredictMoveDuration(dist, speed);
-                    
-                var durationData = BitConverter.GetBytes(duration);
-                _launchData[2] = durationData[0];
-                _launchData[3] = durationData[1];
-                _launchData[4] = durationData[2];
-                _launchData[5] = durationData[3];
-                
-                //SuperController.LogMessage(string.Format("Sending: P:{0}, S:{1}, D:{2}", pos, speed, duration));
-                
-                _network.Send(_launchData, _launchData.Length);
 
+                _network.SendLinearCmd(duration, pos);
+                _network.SendVibrateCmd(pos);
+                    
                 _lastSentLaunchPos = pos;
             }
         }

--- a/VAMLaunch/src/VAMLaunch.cs
+++ b/VAMLaunch/src/VAMLaunch.cs
@@ -268,7 +268,15 @@ namespace VAMLaunchPlugin
                 float duration = LaunchUtils.PredictMoveDuration(dist, speed);
 
                 _network.SendLinearCmd(duration, pos);
-                _network.SendVibrateCmd((float)(pos * (speed / 100.0)));
+
+                if(speed <= 20)
+                {
+                    _network.SendVibrateCmd(0);
+                }
+                else
+                {
+                    _network.SendVibrateCmd((float)(pos * (speed / 100.0)));
+                }
 
                 _lastSentLaunchPos = pos;
             }

--- a/VAMLaunch/src/VAMLaunch.cs
+++ b/VAMLaunch/src/VAMLaunch.cs
@@ -34,14 +34,16 @@ namespace VAMLaunchPlugin
         {
             "Oscillate",
             "Pattern",
-            "Zone"
+            "Zone",
+            "Manual"
         };
 
         private List<IMotionSource> _motionSources = new List<IMotionSource>
         {
             new OscillateSource(),
             new PatternSource(),
-            new ZoneSource()
+            new ZoneSource(),
+            new ManualSource()
         };
         
         public override void Init()
@@ -234,7 +236,23 @@ namespace VAMLaunchPlugin
             }
         }
 
-        
+        public void SetVibration(int device, int motor, float percent)
+        {
+            if(_network == null)
+            {
+                return;
+            }
+
+            if(_pauseLaunchMessages.val)
+            {
+                return;
+            }
+
+            percent = Mathf.Clamp01(percent);
+
+            _network.SendVibrateCmd(device, motor, percent * 100);
+        }
+
         private void SendLaunchPosition(byte pos, byte speed)
         {
             SetSimulatorTarget(pos, speed);
@@ -250,8 +268,8 @@ namespace VAMLaunchPlugin
                 float duration = LaunchUtils.PredictMoveDuration(dist, speed);
 
                 _network.SendLinearCmd(duration, pos);
-                _network.SendVibrateCmd(pos);
-                    
+                _network.SendVibrateCmd((float)(pos * (speed / 100.0)));
+
                 _lastSentLaunchPos = pos;
             }
         }

--- a/VAMLaunch/src/VAMLaunchNetwork.cs
+++ b/VAMLaunch/src/VAMLaunchNetwork.cs
@@ -113,5 +113,85 @@ namespace VAMLaunchPlugin
         {
             return _recvQueue.Count > 0 ? _recvQueue.Dequeue() : null;
         }
+
+        private const byte LINEAR_CMD = 0;
+        private const byte VIBRATE_CMD = 1;
+        private const byte ROTATE_CMD = 2;
+        private const byte DEVICE_ALL = 0;
+        private const byte MOTOR_ALL = 0;
+
+        public void SendLinearCmd(int device, int motor, float duration, float position)
+        {
+            byte[] data = new byte[4 + 4 + 4];
+            data[0] = (byte)data.Length;
+            data[1] = LINEAR_CMD;
+            data[2] = (byte)device;
+            data[3] = (byte)motor;
+
+            var durationData = BitConverter.GetBytes(duration);
+            data[4] = durationData[0];
+            data[5] = durationData[1];
+            data[6] = durationData[2];
+            data[7] = durationData[3];
+
+            var positionData = BitConverter.GetBytes(position);
+            data[8] = positionData[0];
+            data[9] = positionData[1];
+            data[10] = positionData[2];
+            data[11] = positionData[3];
+
+            Send(data, data.Length);
+        }
+
+        public void SendLinearCmd(float duration, float position)
+        {
+            SendLinearCmd(DEVICE_ALL, MOTOR_ALL, duration, position);
+        }
+
+        public void SendVibrateCmd(int device, int motor, float speed)
+        {
+            byte[] data = new byte[4 + 4];
+            data[0] = (byte)data.Length;
+            data[1] = VIBRATE_CMD;
+            data[2] = (byte)device;
+            data[3] = (byte)motor;
+
+            var speedData = BitConverter.GetBytes(speed);
+            data[4] = speedData[0];
+            data[5] = speedData[1];
+            data[6] = speedData[2];
+            data[7] = speedData[3];
+
+            Send(data, data.Length);
+        }
+
+        public void SendVibrateCmd(float speed)
+        {
+            SendVibrateCmd(DEVICE_ALL, MOTOR_ALL, speed);
+        }
+
+        public void SendRotateCmd(int device, int motor, float speed, bool clockwise)
+        {
+            byte[] data = new byte[4 + 4 + 1];
+            data[0] = (byte)data.Length;
+            data[1] = ROTATE_CMD;
+            data[2] = (byte)device;
+            data[3] = (byte)motor;
+
+            var speedData = BitConverter.GetBytes(speed);
+            data[4] = speedData[0];
+            data[5] = speedData[1];
+            data[6] = speedData[2];
+            data[7] = speedData[3];
+
+            data[8] = clockwise ? (byte)1 : (byte)0;
+
+            Send(data, data.Length);
+        }
+
+        public void SendRotateCmd(float speed, bool clockwise)
+        {
+            SendRotateCmd(DEVICE_ALL, MOTOR_ALL, speed, clockwise);
+        }
     }
 }

--- a/VaMLaunchGUI/IntifaceControl.xaml.cs
+++ b/VaMLaunchGUI/IntifaceControl.xaml.cs
@@ -278,14 +278,23 @@ namespace VaMLaunchGUI
         public async Task Vibrate(int device, int motor, double aSpeed)
         {
             var devices = DevicesList;
+            //Console.WriteLine("---------");
+            //Console.WriteLine($"Vibrate {device} {motor} {aSpeed}");
             if (device != Command.DEVICE_ALL) {
-                if(DevicesList.Count >= device)
+                var singleDevice = DevicesList.FirstOrDefault(d => d.Device.Index == device - 1);
+                if(singleDevice != null)
                 {
-                    devices = new ObservableCollection<CheckedListItem> { DevicesList[device - 1] };
+                    //Console.WriteLine($"found device {device}");
+                    devices = new ObservableCollection<CheckedListItem> { singleDevice };
+                }
+                else
+                {
+                    //Console.WriteLine($"no found device {device}");
+                    devices = new ObservableCollection<CheckedListItem>();
                 }
             }
 
-            foreach (var deviceItem in DevicesList)
+            foreach (var deviceItem in devices)
             {
                 if(!deviceItem.IsChecked)
                 {
@@ -313,14 +322,23 @@ namespace VaMLaunchGUI
         public async Task Linear(int device, int motor, uint aDuration, double aPosition)
         {
             var devices = DevicesList;
+            //Console.WriteLine("---------");
+            //Console.WriteLine($"Linear {device} {motor} {aDuration} {aPosition}");
             if (device != Command.DEVICE_ALL) {
-                if(DevicesList.Count >= device)
+                var singleDevice = DevicesList.FirstOrDefault(d => d.Device.Index == device - 1);
+                if(singleDevice != null)
                 {
-                    devices = new ObservableCollection<CheckedListItem> { DevicesList[device - 1] };
+                    //Console.WriteLine($"found device {device}");
+                    devices = new ObservableCollection<CheckedListItem> { singleDevice };
+                }
+                else
+                {
+                    //Console.WriteLine($"no found device {device}");
+                    devices = new ObservableCollection<CheckedListItem>();
                 }
             }
 
-            foreach (var deviceItem in DevicesList)
+            foreach (var deviceItem in devices)
             {
                 if(!deviceItem.IsChecked)
                 {

--- a/VaMLaunchGUI/MainWindow.xaml.cs
+++ b/VaMLaunchGUI/MainWindow.xaml.cs
@@ -44,19 +44,30 @@ namespace VaMLaunchGUI
             _serverTask = new Task (() => server.UpdateThread());
             _serverTask.Start();
             // This is an event handler that will be executed on an outside thread, so remember to use dispatcher.
-            server.PositionUpdate += OnPositionUpdate;
+            server.CommandUpdate += OnCommandEvent;
         }
 
-        protected void OnPositionUpdate(object aObj, PositionUpdateEventArgs e)
+        protected void OnCommandEvent(object aObj, CommandEventArgs e)
         {
             Dispatcher.Invoke(async () =>
             {
-                if (!_positionReceived)
-                {
-                    ConnectionStatus.Content = "Connected to VaM";
-                }
+            if (!_positionReceived)
+            {
+                ConnectionStatus.Content = "Connected to VaM";
+            }
 
-                await _intifaceTab.Linear((uint)(e.Duration * 1000), (double)(e.Position / 100.0));
+            switch (e.Command.Type)
+            {
+                case Command.LINEAR_CMD:
+                    await _intifaceTab.Linear(e.Command.Device, e.Command.Motor, (uint)(e.Command.Params[0] * 1000), e.Command.Params[1] / 100.0);
+                    break;
+                case Command.VIBRATE_CMD:
+                    await _intifaceTab.Vibrate(e.Command.Device, e.Command.Motor, e.Command.Params[0] / 100.0);
+                    break;
+                case Command.ROTATE_CMD:
+                    // TODO: implement
+                    break;
+                }
             });
         }
     }

--- a/VaMLaunchGUI/VaMLaunchGUI.csproj
+++ b/VaMLaunchGUI/VaMLaunchGUI.csproj
@@ -39,8 +39,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Buttplug, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Buttplug.2.0.2\lib\net47\Buttplug.dll</HintPath>
+    <Reference Include="Buttplug, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Buttplug.2.0.3\lib\net47\Buttplug.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.17.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Protobuf.3.17.0\lib\net45\Google.Protobuf.dll</HintPath>

--- a/VaMLaunchGUI/packages.config
+++ b/VaMLaunchGUI/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Buttplug" version="2.0.2" targetFramework="net472" />
+  <package id="Buttplug" version="2.0.3" targetFramework="net472" />
   <package id="ButtplugRustFFI" version="2.0.2" targetFramework="net472" />
   <package id="Google.Protobuf" version="3.17.0" targetFramework="net472" />
   <package id="MaterialDesignColors" version="2.0.0" targetFramework="net472" />


### PR DESCRIPTION
Server now accepts lower level commands from the VaM plugin.

This allows the VaM client. to make decisions on the devices and motors that should be turned on and off instead of having the smarts in the server.

Hope this makes it convenient to add new functions in VaM without recompiling the server.
